### PR TITLE
Updates for a new PiPPs CausalGym condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 <div align="center">
-
 # CausalGym
+</div>
 
-**[CausalGym: Benchmarking causal interpretability methods on linguistic tasks](https://arxiv.org/abs/2402.12560)**\
-(Arora et al., 2024)
-  
+Aryaman Arora, Dan Jurafsky, and Christopher Potts. 2024. [CausalGym: Benchmarking causal interpretability methods on linguistic tasks](https://aclanthology.org/2024.acl-long.785/). In _Proceedings of the 62nd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)_, pages 14638–14663, Bangkok, Thailand. Association for Computational Linguistics.
+
 *HuggingFace dataset*: [aryaman/causalgym](https://huggingface.co/datasets/aryaman/causalgym)
 
-</div>
+
 
 **CausalGym** is a benchmark for comparing the performance of causal interpretability methods on a variety of simple linguistic tasks taken from the SyntaxGym evaluation set ([Gauthier et al., 2020](https://aclanthology.org/2020.acl-demos.10/), [Hu et al., 2020](https://aclanthology.org/2020.acl-main.158/)) and converted into a format suitable for interventional interpretability.
 
@@ -23,7 +22,7 @@ If you are having trouble getting anything running, do not hesitate to file an i
 
 ## Instructions
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > The implementations in this repo are only for `GPTNeoX`-type language models (e.g. the `pythia` series) and will probably not work for other architectures without some modifications.
 
 First install the requirements (a fresh environment is probably best):
@@ -46,12 +45,19 @@ To do the same but with the dog-give control task used to compute selectivity:
 python test_all.py --model EleutherAI/pythia-70m --manipulate dog-give
 ```
 
+To run just the Preposing in PP extension:
+
+```bash
+python test_all.py --model EleutherAI/pythia-70m --datasets preposing_in_pp/preposing_in_pp preposing_in_pp/preposing_in_pp_embed_1
+```
+
+
 ### Analysis + plots
 
 Once you have run this for several models, you can create results tables (like those found in the appendix) with:
 
 ```bash
-python plot.py --file logs/das/ --plot summary --metrics odds --reload
+python plot.py --file logs/das/ --plot summary --metric odds --reload
 ```
 
 This also caches intermediate results in csv file in the directory, so you don't need to use the `--reload` option again unless you need to recompute statistics.
@@ -59,21 +65,41 @@ This also caches intermediate results in csv file in the directory, so you don't
 To produce the causal tracing-style plots for all methods:
 
 ```bash
-python plot.py --file logs/das/ --plot pos_all --metrics odds
+python plot.py --file logs/das/ --plot pos_all --metric odds
 ```
+
+To visualize just runs from the Preposing in PP extension:
+
+```bash
+python plot.py --file logs/das/ --plot pos_all --metric odds --template_filename preposing_in_pp
+```
+
+You can also specify a subset of methods:
+
+```bash
+python plot.py --file logs/das/ --plot pos_t --metric odds --methods das vanilla probe
+```
+
 
 ## Citation
 
-Please cite the CausalGym preprint:
+Please cite the CausalGym publication:
 
 ```bibtex
-@article{arora-etal-2024-causalgym,
+@inproceedings{arora-etal-2024-causalgym,
     title = "{C}ausal{G}ym: Benchmarking causal interpretability methods on linguistic tasks",
     author = "Arora, Aryaman and Jurafsky, Dan and Potts, Christopher",
-    journal = "arXiv:2402.12560",
+    editor = "Ku, Lun-Wei and Martins, Andre and Srikumar, Vivek",
+    booktitle = "Proceedings of the 62nd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = aug,
     year = "2024",
-    url = "https://arxiv.org/abs/2402.12560"
+    address = "Bangkok, Thailand",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2024.acl-long.785",
+    doi = "10.18653/v1/2024.acl-long.785",
+    pages = "14638--14663"
 }
+
 ```
 
 Also cite the earlier SyntaxGym papers:

--- a/data/templates/preposing_in_pp.json
+++ b/data/templates/preposing_in_pp.json
@@ -1,0 +1,74 @@
+{
+    "preposing_in_pp": {
+        "templates": [
+            "{prefix}{filler} though {subj} {verb}"
+        ],
+        "label": "filler",
+        "result_prepend_space": false,
+        "labels": {
+            "pp": [" happy", " sad", " anxious", " afraid", " nervous", " wary", " weary",
+		   " suspicious", " doubtful", " clever", " witty", " young", " old",
+		   " sharp", " bright", " intelligent"
+		  ],
+            "pipp": ["."]
+        },
+        "variables": {
+	    "prefix": ["The work continued,", "The plan was in motion,"],
+	    "subj": ["the mother", "the security guard", "the man", "the delivery boy",
+		      "the judge", "the reporter", "the accountant", "the secretary",
+		      "the investigator", "the businessman", "the friend", "the painter",
+		      "the neighbor", "the woman", "the politician", "the old man"
+		     ],
+
+            "filler": {
+                "pp": [""],
+                "pipp": [" happy", " sad", " anxious", " afraid", " nervous", " wary", " weary",
+			 " suspicious", " doubtful", " clever", " witty", " young", " old",
+			 " sharp", " bright", " intelligent"
+			]
+            },
+            "verb": ["seemed", "seems"]
+        }
+    },
+    "preposing_in_pp_embed_1": {
+        "templates": [
+             "{prefix}{filler} though {subj1} {verb1} that {subj2} {verb2}"
+        ],
+        "label": "filler",
+        "result_prepend_space": false,
+        "labels": {
+            "pp": [" happy", " sad", " anxious", " afraid", " nervous", " wary", " weary",
+		   " suspicious", " doubtful", " clever", " witty", " young", " old",
+		   " sharp", " bright", " intelligent"
+		  ],
+            "pipp": ["."]
+        },
+        "variables": {
+	        "prefix": ["The work continued,", "The plan was in motion,"],
+	        "subj1": ["the mother", "the security guard", "the man", "the delivery boy",
+		      "the judge", "the reporter", "the accountant", "the secretary",
+		      "the investigator", "the businessman", "the friend", "the painter",
+		      "the neighbor", "the woman", "the politician", "the old man"
+		     ],
+	        "verb1": ["said", "believed", "knew", "remarked", "heard",
+			"thought", "stated", "said", "said", "thought",
+			"believes", "believed", "said", "said", "said",
+			"thinks", "said", "stated", "believed", "stated"
+		       ],
+            "subj2": ["the friend", "the assistant", "the woman", "the worker", "the newspaper",
+		      "the cop", "the television host", "the colleague", "the journalist",
+		      "the banker", "the colleague", "the rival", "the reporter", "the associate",
+		      "the worker", "the cop", "the mother", "the secretary", "the friend",
+		      "the press secretary", "the woman"
+              ],
+            "filler": {
+                "pp": [""],
+                "pipp": [" happy", " sad", " anxious", " afraid", " nervous", " wary", " weary",
+			 " suspicious", " doubtful", " clever", " witty", " young", " old",
+			 " sharp", " bright", " intelligent"
+			]
+            },
+            "verb2": ["seemed", "seems"]
+        }
+    }
+}

--- a/eval.py
+++ b/eval.py
@@ -29,6 +29,7 @@ def eval(intervenable: pv.IntervenableModel, evalset: list[Batch],
             batch.base,
             [None, batch.src],
             {"sources->base": ([None, pos_interv[1]], pos_interv)},
+            output_original_output=True
         )
 
         # store activations/labels for training non-causal methods
@@ -63,7 +64,7 @@ def eval(intervenable: pv.IntervenableModel, evalset: list[Batch],
                 "layer": layer_i,
                 "pos": pos_i
             })
-    
+
     # summary metrics
     summary = {
         "iia": sum([d['p_src'] > d['p_base'] for d in data]) / len(data),
@@ -71,7 +72,7 @@ def eval(intervenable: pv.IntervenableModel, evalset: list[Batch],
         "odds_ratio": sum([d['base_p_base'] - d['base_p_src'] + d['p_src'] - d['p_base'] for d in data]) / len(data),
         "eval_loss": sum([d['loss'] for d in data]) / len(data),
     }
-    
+
     # update iterator
     return data, summary, activations
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 numpy==1.26.4
-pandas==2.2.0
-plotnine==0.12.4
-pyvene
-scikit_learn==1.3.2
-scipy==1.12.0
-torch==2.0.1
-tqdm==4.66.1
-transformers==4.37.2
+pandas==2.2.2
+plotnine==0.14.1
+pyvene==0.1.6
+scikit_learn==1.5.2
+scipy==1.13.1
+torch==2.5.1
+tqdm==4.66.6
+transformers==4.46.2

--- a/test_all.py
+++ b/test_all.py
@@ -44,7 +44,7 @@ def run_command(
 def main(
     model: str, lr: float=5e-3, hparam_non_das: bool=False, only_das: bool=False,
     das_label: str=None, start: int=None, end: int=None, folder: str="das", revision: str="main",
-    manipulate: str=False):
+    manipulate: str=False, datasets: str=None):
 
     # load model + tokenizer
     device = "cuda:0" if torch.cuda.is_available() else "cpu"
@@ -57,7 +57,8 @@ def main(
     ).to(device)
 
     # run commands
-    datasets = [d for d in list_datasets() if d.startswith("syntaxgym/")]
+    if datasets is None:
+        datasets = [d for d in list_datasets() if d.startswith("syntaxgym/")]
     print(len(datasets))
 
     # start/end
@@ -85,5 +86,6 @@ if __name__ == "__main__":
     parser.add_argument("--folder", type=str, default="das")
     parser.add_argument("--revision", type=str, default="main")
     parser.add_argument("--manipulate", type=str, default=None)
+    parser.add_argument("--datasets", nargs='+', default=None)
     args = parser.parse_args()
     main(**vars(args))


### PR DESCRIPTION
Hey @aryamanarora,

This is a proposed update to handle the PiPPs experiments I am planning to report on in my LSA talk in January.

Summary of changes:

1. My basic proposal is to contribute `preposing_in_pp.json` as a new CausalGym condition. It's in a separate file to preserve the original CausalGym.
2. To accommodate this, I added a `--datasets` option to `test_all.py`. This lets you have things like `--datasets preposing_in_pp/preposing_in_pp preposing_in_pp/preposing_in_pp_embed_1` to run my new methods. You can also use it to run a subset of conditions from `syntaxgym.json`. The default is to run all of `syntaxgym.json`, so this is backward compatible.
3. For plotting, I am using only `plot_per_pos` for now from `plot.py`. So that I could use this, I added a new command line argument `--template_filename` and removed the hardcoded `syntaxgym` strings. The default is `template_filename="syntaxgym"`, so this is backward compatible.
4. I wanted to view arbitrary subsets of the different methods, not just "all" or ["das", "probe"], so I added a `--methods` command-line argument. You can do things like `--methods das vanilla`. The default is ` methods=("das", "probe")`, so this is backward compatible.
5. The scaling of the plots was not working well for me, so I added `--scale_plots`. The default is `False`, and this will do exactly what the repo did before. If you do `--scale_plots true`, then it will use the number of models and methods to try to produce a nice looking plot.
6. I updated `requirements.txt`. I stuck with your strict equalities for all packages, and I specified the version for `pyvene`. The set-up here is the current set of defaults for Colab.

Other comments:

1. The logic of `pos`, `pos_t`, and `pos_all` as arguments for `--plot` seems tricky to me. If I have the logic correct, `plot_all` overrides the others and `pos_t` is very specialized. It seems like we could reduce all of this to my `--methods` argument with a default to plot all of them. Using `--plot pos` would signal this path into `plot_per_pos`.
2. We could remove `--scale_plots` entirely and use something like my scaling logic, but this would result in slightly different sizes for the plots compared to what is in the publication.
3. It would be nice to support any subset of methods in `test_all.py`, to allow for more than just all methods or only das. I would be happy to implement this,